### PR TITLE
Allow other test file suffixes... specifically 'spec'

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
   "engines": {
     "vscode": "^1.0.0"
   },
-  "categories": ["Other"],
-  "activationEvents": ["onCommand:extension.jestGoToTest"],
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:extension.jestGoToTest"
+  ],
   "main": "./out/src/extension",
   "contributes": {
     "commands": [
@@ -27,7 +31,21 @@
         "mac": "cmd+shift+y",
         "when": "editorTextFocus"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Jest Go To Test",
+      "properties": {
+        "jestGoToTest.testSuffix": {
+          "type": "string",
+          "enum": [
+            "test",
+            "spec"
+          ],
+          "default": "test",
+          "description": "The suffix of your test files"
+        }
+      }
+    }
   },
   "scripts": {
     "test": "jest",
@@ -36,7 +54,10 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "jest": {
-    "moduleFileExtensions": ["ts", "js"],
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
     "transform": {
       "\\.(ts)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
-import * as resolver from './resolver';
+import { Resolver } from './resolver';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mkdirp from 'mkdirp';
@@ -18,47 +18,49 @@ function prompt(fileName, cb) {
 		placeHolder: `Create ${fileName}?`
 	}
 	vscode.window.showQuickPick(["Yes", "No"], options)
-			.then(function(answer) {
-				if (answer === "Yes") {
-					cb();
-				}
-			});
+		.then(function (answer) {
+			if (answer === "Yes") {
+				cb();
+			}
+		});
 }
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	const config = vscode.workspace.getConfiguration("jestGoToTest")
+	const resolver = new Resolver(config.get("testSuffix"))
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with  registerCommand
 	// The commandId parameter must match the command field in package.json
 	let disposable = vscode.commands.registerCommand('extension.jestGoToTest', () => {
-	// The code you place here will be executed every time your command is executed
+		// The code you place here will be executed every time your command is executed
 
-	// Display a message box to the user
-	var editor = vscode.window.activeTextEditor;
-	if (!editor) {
-		return; // No open text editor
-	}
+		// Display a message box to the user
+		var editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return; // No open text editor
+		}
 
-	let document = editor.document;
-	let fileName: string = document.fileName;
-	let related: string = resolver.getRelated(fileName);
-	let relative: string = vscode.workspace.asRelativePath(related);
-	let fileExists: boolean = fs.existsSync(related);
-	let dirname: string = path.dirname(related);
-	
-	//console.log('fileExists', fileExists);
+		let document = editor.document;
+		let fileName: string = document.fileName;
+		let related: string = resolver.getRelated(fileName);
+		let relative: string = vscode.workspace.asRelativePath(related);
+		let fileExists: boolean = fs.existsSync(related);
+		let dirname: string = path.dirname(related);
 
-	if (fileExists) {
-		openFile(related);
-	} else {
-		prompt(relative, function() {
-			mkdirp.sync(dirname);
-			fs.closeSync(fs.openSync(related, 'w'));
+		//console.log('fileExists', fileExists);
+
+		if (fileExists) {
 			openFile(related);
-		});
-	}
+		} else {
+			prompt(relative, function () {
+				mkdirp.sync(dirname);
+				fs.closeSync(fs.openSync(related, 'w'));
+				openFile(related);
+			});
+		}
 
 	});
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,21 +1,27 @@
-export function getRelated(file) {
-  if (isSpec(file)) {
-    return specToCode(file);
-  } else {
-    return codeToSpec(file);
+export class Resolver {
+  constructor(private suffix: string) {
+    console.log(suffix)
   }
-}
 
-export function isSpec(file) {
-  return file.indexOf(".spec") > -1 || file.indexOf(".test") > -1;
-}
+  public getRelated(file) {
+    if (this.isSpec(file)) {
+      return this.specToCode(file);
+    } else {
+      return this.codeToSpec(file);
+    }
+  }
 
-export function codeToSpec(file: string) {
-  if (file.includes(".js")) return file.replace(".js", ".test.js");
-  if (file.includes(".ts")) return file.replace(".ts", ".test.ts");
-}
+  private isSpec(file) {
+    return file.indexOf(`.${this.suffix}`) > -1;
+  }
 
-export function specToCode(file: string) {
-  if (file.includes(".js")) return file.replace(".test.js", ".js");
-  if (file.includes(".ts")) return file.replace(".test.ts", ".ts");
+  private codeToSpec(file: string) {
+    if (file.includes(".js")) return file.replace(".js", `.${this.suffix}.js`);
+    if (file.includes(".ts")) return file.replace(".ts", `.${this.suffix}.ts`);
+  }
+
+  private specToCode(file: string) {
+    if (file.includes(".js")) return file.replace(`.${this.suffix}.js`, ".js");
+    if (file.includes(".ts")) return file.replace(`.${this.suffix}.ts`, ".ts");
+  }
 }


### PR DESCRIPTION
it is a common convention to use .spec.* to denote test files so this PR facilitates that naming convention. We still use .test.* as the default so this should be backwards compatible. We also still support js and ts. Let me know if you have any concerns.